### PR TITLE
Add EDM4hep timing test file

### DIFF
--- a/EDM4hep/.gitignore
+++ b/EDM4hep/.gitignore
@@ -1,0 +1,2 @@
+data/
+Manifest.toml

--- a/EDM4hep/Project.toml
+++ b/EDM4hep/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
+EDM4hep = "eb32b910-dde9-4347-8fce-cd6be3498f0c"
+JetReconstruction = "44e8cb2c-dfab-4825-9c70-d4808a591196"

--- a/EDM4hep/src/EDM4hepJetsTimed.jl
+++ b/EDM4hep/src/EDM4hepJetsTimed.jl
@@ -1,0 +1,61 @@
+using ArgParse
+using EDM4hep
+using EDM4hep.RootIO
+using JetReconstruction
+using Logging
+
+function parse_command_line(args)
+    s = ArgParseSettings(autofix_names = true)
+    @add_arg_table! s begin
+        "--maxevents", "-n"
+        help = "Maximum number of events to read (default 1; -1 means read all events)."
+        arg_type = Int
+        default = 1
+
+        "file"
+        help = "EDM4hep events file to read"
+        required = true
+    end
+    return parse_args(args, s; as_symbols = true)
+end
+
+function main()
+    args = parse_command_line(ARGS)
+    logger = ConsoleLogger(stdout, Logging.Info)
+    global_logger(logger)
+
+    # Open input event file
+    global_timer_start = time_ns()
+    reader = RootIO.Reader(args[:file])
+    events = RootIO.get(reader, "events")
+
+    total_time = 0.0
+    count = 0
+
+    # Reconstruct each event
+    for (ievt, evt) in enumerate(events)
+        count += 1
+        if args[:maxevents] > 0 && ievt > args[:maxevents]
+            break
+        end
+        recps = RootIO.get(reader, evt, "ReconstructedParticles")
+
+        start_jet = time_ns()
+        _ = jet_reconstruct(recps; algorithm = JetAlgorithm.Durham)
+        end_jet = time_ns()
+        total_time += end_jet - start_jet
+        # @info begin
+        #     jets = "Event $(ievt)\n"
+        #     for jet in exclusive_jets(cs; njets = 2, T = EEjet)
+        #         jets *= " $jet\n"
+        #     end
+        #     jets
+        # end
+    end
+    global_timer_stop = time_ns()
+    println("Reconstructed $(count) events in $(total_time/1.0e9) s: rate = $((count * 1.0e9) / total_time)")
+    println("Total time: $((global_timer_stop - global_timer_start)/1.0e9) s")
+    count, total_time
+end
+
+main()


### PR DESCRIPTION
This uses a separate Project.toml as it's a bit tricky with Makie right now (due to FHist version lock in EDM4hep and then FHist 0.8's Makie compatibility).

Do not store data file - it's too big, but the standard test is from:

/eos/experiment/fcc/ee/generation/DelphesEvents/winter2023/IDEA/wzp6_ee_nunuH_Hss_ecm240/events_196755633.root