### PR TITLE
Sort fastjet output jets only when dumping

### DIFF
--- a/fastjet/src/fastjet-finder.cc
+++ b/fastjet/src/fastjet-finder.cc
@@ -207,8 +207,6 @@ int main(int argc, char* argv[]) {
       if (ptmin_option->is_set()) {
         final_jets = fastjet::sorted_by_pt(cluster_sequence.inclusive_jets(ptmin_option->value()));
       } else if (dijmax_option->is_set()) {
-        cout << "dijmax: " << dijmax_option->value() << endl;
-        final_jets = fastjet::sorted_by_pt(cluster_sequence.inclusive_jets(ptmin_option->value()));
         final_jets = fastjet::sorted_by_pt(cluster_sequence.exclusive_jets(dijmax_option->value()));
       } else if (njets_option->is_set()) {
         final_jets = fastjet::sorted_by_pt(cluster_sequence.exclusive_jets(njets_option->value()));

--- a/fastjet/src/fastjet-finder.cc
+++ b/fastjet/src/fastjet-finder.cc
@@ -205,15 +205,17 @@ int main(int argc, char* argv[]) {
 
       vector<fastjet::PseudoJet> final_jets;
       if (ptmin_option->is_set()) {
-        final_jets = fastjet::sorted_by_pt(cluster_sequence.inclusive_jets(ptmin_option->value()));
+        final_jets = cluster_sequence.inclusive_jets(ptmin_option->value());
       } else if (dijmax_option->is_set()) {
-        final_jets = fastjet::sorted_by_pt(cluster_sequence.exclusive_jets(dijmax_option->value()));
+        final_jets = cluster_sequence.exclusive_jets(dijmax_option->value());
       } else if (njets_option->is_set()) {
-        final_jets = fastjet::sorted_by_pt(cluster_sequence.exclusive_jets(njets_option->value()));
+        final_jets = cluster_sequence.exclusive_jets(njets_option->value());
       }
 
       if (dump_option->is_set() && trial==0) {
-         fprintf(dump_fh, "Jets in processed event %zu\n", ievt+1);
+        // sort by pt so files can be compared
+        final_jets = fastjet::sorted_by_pt(final_jets);
+        fprintf(dump_fh, "Jets in processed event %zu\n", ievt+1);
     
         // print out the details for each jet
         for (unsigned int i = 0; i < final_jets.size(); i++) {


### PR DESCRIPTION
Fastjet benchmark is sorting jets after selection while JetReconstruction benchmark doesn't. I propose to sort fastjet output only when dumping as it's quite useful to compare files (for instance with C-bindings for JetReconstruction)

Also there seems to be extra printout and extra call to `inclusive_jets` when `exclusive_jets` with dcut was supposed to happen.