### PR TITLE
adapt to changed signatures for function passing types

### DIFF
--- a/EDM4hep/src/EDM4hepJetsTimed.jl
+++ b/EDM4hep/src/EDM4hepJetsTimed.jl
@@ -46,7 +46,7 @@ function main()
         total_time += end_jet - start_jet
         # @info begin
         #     jets = "Event $(ievt)\n"
-        #     for jet in exclusive_jets(cs; njets = 2, T = EEjet)
+        #     for jet in exclusive_jets(cs, EEJet; njets = 2)
         #         jets *= " $jet\n"
         #     end
         #     jets

--- a/src/benchmark-substructure.jl
+++ b/src/benchmark-substructure.jl
@@ -20,7 +20,7 @@ function get_exclusive_jet_selection(filename, ptmin, R)
     events = read_final_state_particles(filename)
     for event in events
         cs = jet_reconstruct(event; p=0, R = R)
-        push!(exclusive_jets, inclusive_jets(cs; ptmin=ptmin, T=PseudoJet))
+        push!(exclusive_jets, inclusive_jets(cs, PseudoJet; ptmin=ptmin))
         push!(cluster_seqs, cs)
     end
     (cluster_seqs, exclusive_jets)

--- a/src/benchmark.jl
+++ b/src/benchmark.jl
@@ -363,7 +363,7 @@ function main()
             else
                 JetType = PseudoJet
             end
-            events::Vector{Vector{JetType}} = read_final_state_particles(event_file; T = JetType)
+            events::Vector{Vector{JetType}} = read_final_state_particles(event_file, JetType)
             time_per_event = julia_jet_process_avg_time(events; ptmin = args[:ptmin],
             radius = args[:radius],
             algorithm = args[:algorithm],

--- a/src/thread-run.jl
+++ b/src/thread-run.jl
@@ -178,11 +178,11 @@ function main()
 
     # Try to read events into the correct type!
     if JetReconstruction.is_ee(args[:algorithm])
-        JetType = EEjet
+        JetType = EEJet
     else
         JetType = PseudoJet
     end
-    events::Vector{Vector{JetType}} = read_final_state_particles(args[:file]; T = JetType)
+    events::Vector{Vector{JetType}} = read_final_state_particles(args[:file], JetType)
     if isnothing(args[:algorithm]) && isnothing(args[:power])
         @warn "Neither algorithm nor power specified, defaulting to AntiKt"
         args[:algorithm] = JetAlgorithm.AntiKt


### PR DESCRIPTION
Update to work with JetReconstruction after passing types as arguments for functions was changed to avoid instabilities  https://github.com/JuliaHEP/JetReconstruction.jl/pull/187

Also some missed `EEjet` -> `EEJet` 