### PR TITLE
fixed existing fastjet issues and created parallel benchmarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Main directory of source files and utilities for benchmarking:
 
 - `benchmark.jl` run timing tests for different backends, allowing switching of
   algorithm, strategy, etc. (will run over multiple event input files)
+- `thread-run.jl`, `thread-scan.sh`, and `thread-benchmark-all.sh` run the
+  Julia thread-scaling workflow described in `THREAD.md`
+- `merge-thread-scan.jl` and `plot-thread-scan.jl` merge and plot thread-scan
+  outputs; they can be used with Julia JSON files and benchmark CSV files
 - `generate-benchmarks-{pp,ee,antikt}.sh` example files of how to generate a set
   of benchmark files for various parameters
 - `merge-results.jl` merges per run-parameters output CSV files into only large
@@ -72,7 +76,7 @@ fragile and not very extensible, so has been archived.
 
 ## Benchmarking - Single Runs
 
-Here we describe what to do to measure events/s using `benchmark.jl` with
+Here we describe what to do to measure event/s using `benchmark.jl` with
 different versions of the sequential jet algorithm codes for a single set of
 parameters, usually over a range of input files.
 
@@ -108,6 +112,11 @@ cmake --build build
 ```
 
 Evidently you can use whatever compiler and flags you like.
+
+For FastJet thread scaling, build `fastjet-finder` with OpenMP support. The
+executable accepts `--threads` and `--schedule`, and `benchmark.jl` forwards
+these options when `--code Fastjet` is selected. See `THREAD.md` for the full
+Julia-vs-FastJet thread-scaling workflow.
 
 #### Python
 
@@ -172,17 +181,22 @@ In general the former is used for testing and the latter for full benchmark runs
 - `--radius R`: for algorithms which have a variable radius parameter, this is set to `R` (default 0.4)
 - `--power p`: for algorithms which have a variable power, this is set to `p` - for algorithms with a fixed power this must be set *consistently* or the run will be aborted
 - `--ptmin PTMIN`: for these benchmarking runs an inclusive jet selection will be done with this `ptmin` cut (this has little influence on the results)
+- `--threads N`: thread count to record in the output; for `JetReconstruction`
+  this should match `julia --threads=N`, while for `Fastjet` it is passed to
+  `fastjet-finder`
+- `--schedule {static,dynamic,guided}`: OpenMP schedule for `Fastjet`; ignored
+  for Julia and other external backends
 
 ### Recording Benchmarking Runs
 
 To conduct a benchmarking run there are a few other parameters that should be specified:
 
 - `--results OUTPUT`: write the final CSV data out to `OUTPUT`; if `OUTPUT` is a
-  *directory* then `benchmarking.jl` will use an ~unique filename determined from
+  *directory* then `benchmark.jl` will use a unique filename determined from
   the parameters of run - this should be sufficient for a systematic series of
   benchmark runs
 - `--code-version`: write the *version* of the code used into the output; there
-  is no good way for `benchmarking.jl` to detect this, so this is a user
+  is no good way for `benchmark.jl` to detect this, so this is a user
   specified string (e.g., `3.4.3` for Fastjet 3.43.; `0.4.6` for a recent
   version of `JetReconstruction.jl`)
 - `--backend`: the backend compiler/interpreter, e.g., `julia` or `gcc`; for

--- a/README.md
+++ b/README.md
@@ -114,9 +114,15 @@ cmake --build build
 Evidently you can use whatever compiler and flags you like.
 
 For FastJet thread scaling, build `fastjet-finder` with OpenMP support. The
-executable accepts `--threads` and `--schedule`, and `benchmark.jl` forwards
-these options when `--code Fastjet` is selected. See `THREAD.md` for the full
-Julia-vs-FastJet thread-scaling workflow.
+executable accepts `--threads` and `--schedule`; `benchmark.jl` forwards
+`--worker-threads` to FastJet's `--threads` option when `--code Fastjet` is
+selected. See `THREAD.md` for the full Julia-vs-FastJet thread-scaling workflow.
+
+```sh
+cd fastjet
+cmake -S . -B build -DFASTJET_ENABLE_OPENMP=ON
+cmake --build build
+```
 
 #### Python
 
@@ -181,9 +187,9 @@ In general the former is used for testing and the latter for full benchmark runs
 - `--radius R`: for algorithms which have a variable radius parameter, this is set to `R` (default 0.4)
 - `--power p`: for algorithms which have a variable power, this is set to `p` - for algorithms with a fixed power this must be set *consistently* or the run will be aborted
 - `--ptmin PTMIN`: for these benchmarking runs an inclusive jet selection will be done with this `ptmin` cut (this has little influence on the results)
-- `--threads N`: thread count to record in the output; for `JetReconstruction`
-  this should match `julia --threads=N`, while for `Fastjet` it is passed to
-  `fastjet-finder`
+- `--worker-threads N`: worker thread count for external backends; for `Fastjet`
+  this is passed to `fastjet-finder --threads N`. For `JetReconstruction`, use
+  `julia --threads=N` instead
 - `--schedule {static,dynamic,guided}`: OpenMP schedule for `Fastjet`; ignored
   for Julia and other external backends
 

--- a/THREAD.md
+++ b/THREAD.md
@@ -246,28 +246,21 @@ This keeps the two timing paths simple:
 
 ```text
 JetReconstruction.jl     run with julia --threads=N
-FastJet                  run fastjet-finder with --threads N
+FastJet                  run benchmark.jl --worker-threads=N, forwarded to fastjet-finder --threads N
 ```
 
 Build `fastjet-finder` with OpenMP before running multi-threaded FastJet
 benchmarks:
 
 ```sh
-cmake -S fastjet -B fastjet/build
+cmake -S fastjet -B fastjet/build -DFASTJET_ENABLE_OPENMP=ON
 cmake --build fastjet/build
 ```
 
-On macOS with Apple clang and Homebrew `libomp`, CMake may need the OpenMP
-settings explicitly:
+For serial FastJet baseline timings, build without OpenMP:
 
 ```sh
-cmake -S fastjet -B fastjet/build \
-  -DCMAKE_PREFIX_PATH=/path/to/fastjet-install \
-  -DHepMC3_DIR=/opt/homebrew/share/HepMC3/cmake \
-  -DOpenMP_CXX_FLAGS="-Xpreprocessor -fopenmp" \
-  -DOpenMP_CXX_INCLUDE_DIR=/opt/homebrew/opt/libomp/include \
-  -DOpenMP_CXX_LIB_NAMES=omp \
-  -DOpenMP_omp_LIBRARY=/opt/homebrew/opt/libomp/lib/libomp.dylib
+cmake -S fastjet -B fastjet/build
 cmake --build fastjet/build
 ```
 
@@ -280,7 +273,7 @@ julia --threads=1 --project=. src/benchmark.jl \
   -S N2Plain \
   -R 0.4 \
   --nsamples 10 \
-  --threads 4 \
+  --worker-threads 4 \
   --schedule dynamic \
   --results results/benchmark-scan/small/fastjet/Fastjet-AntiKt-N2Plain-small-t4-dynamic.csv \
   data/events-pp-0.5TeV-5GeV.hepmc3.gz
@@ -289,7 +282,7 @@ julia --threads=1 --project=. src/benchmark.jl \
 `benchmark.jl` will decompress `.gz` inputs when needed because the FastJet
 reader expects plain `.hepmc3` input. The Julia process itself can usually run
 with `--threads=1` for FastJet points; the measured thread count is the
-`--threads` value passed to `fastjet-finder`.
+`--worker-threads` value that `benchmark.jl` passes to `fastjet-finder`.
 
 For a small FastJet scan:
 
@@ -303,7 +296,7 @@ for threads in 1 2 4 8; do
     -S N2Plain \
     -R 0.4 \
     --nsamples 10 \
-    --threads "$threads" \
+    --worker-threads "$threads" \
     --schedule dynamic \
     --results "results/benchmark-scan/small/fastjet/Fastjet-AntiKt-N2Plain-small-t${threads}-dynamic.csv" \
     data/events-pp-0.5TeV-5GeV.hepmc3.gz

--- a/THREAD.md
+++ b/THREAD.md
@@ -233,6 +233,158 @@ results/thread-scaling/full-small/summary.csv
 results/thread-scaling/full-small/plots/
 ```
 
+## FastJet Thread Scaling
+
+The Julia thread-scaling workflow above uses `thread-run.jl` and writes JSON.
+FastJet is benchmarked through the existing `src/benchmark.jl` CSV path instead:
+
+```text
+benchmark.jl --code Fastjet -> CSV files -> merge-thread-scan.jl -> summary CSV -> plot-thread-scan.jl
+```
+
+This keeps the two timing paths simple:
+
+```text
+JetReconstruction.jl     run with julia --threads=N
+FastJet                  run fastjet-finder with --threads N
+```
+
+Build `fastjet-finder` with OpenMP before running multi-threaded FastJet
+benchmarks:
+
+```sh
+cmake -S fastjet -B fastjet/build
+cmake --build fastjet/build
+```
+
+On macOS with Apple clang and Homebrew `libomp`, CMake may need the OpenMP
+settings explicitly:
+
+```sh
+cmake -S fastjet -B fastjet/build \
+  -DCMAKE_PREFIX_PATH=/path/to/fastjet-install \
+  -DHepMC3_DIR=/opt/homebrew/share/HepMC3/cmake \
+  -DOpenMP_CXX_FLAGS="-Xpreprocessor -fopenmp" \
+  -DOpenMP_CXX_INCLUDE_DIR=/opt/homebrew/opt/libomp/include \
+  -DOpenMP_CXX_LIB_NAMES=omp \
+  -DOpenMP_omp_LIBRARY=/opt/homebrew/opt/libomp/lib/libomp.dylib
+cmake --build fastjet/build
+```
+
+Run one FastJet point with `benchmark.jl`:
+
+```sh
+julia --threads=1 --project=. src/benchmark.jl \
+  --code Fastjet \
+  -A AntiKt \
+  -S N2Plain \
+  -R 0.4 \
+  --nsamples 10 \
+  --threads 4 \
+  --schedule dynamic \
+  --results results/benchmark-scan/small/fastjet/Fastjet-AntiKt-N2Plain-small-t4-dynamic.csv \
+  data/events-pp-0.5TeV-5GeV.hepmc3.gz
+```
+
+`benchmark.jl` will decompress `.gz` inputs when needed because the FastJet
+reader expects plain `.hepmc3` input. The Julia process itself can usually run
+with `--threads=1` for FastJet points; the measured thread count is the
+`--threads` value passed to `fastjet-finder`.
+
+For a small FastJet scan:
+
+```sh
+mkdir -p results/benchmark-scan/small/fastjet
+
+for threads in 1 2 4 8; do
+  julia --threads=1 --project=. src/benchmark.jl \
+    --code Fastjet \
+    -A AntiKt \
+    -S N2Plain \
+    -R 0.4 \
+    --nsamples 10 \
+    --threads "$threads" \
+    --schedule dynamic \
+    --results "results/benchmark-scan/small/fastjet/Fastjet-AntiKt-N2Plain-small-t${threads}-dynamic.csv" \
+    data/events-pp-0.5TeV-5GeV.hepmc3.gz
+done
+```
+
+For comparison, run the matching Julia points either with `thread-scan.sh` or
+with `benchmark.jl`. The `thread-scan.sh` route records more metadata:
+
+```sh
+./src/thread-scan.sh \
+  --outdir results/benchmark-scan/small/julia/AntiKt-N2Plain \
+  --algorithm AntiKt \
+  --strategy N2Plain \
+  --input-file data/events-pp-0.5TeV-5GeV.hepmc3.gz \
+  --label small \
+  --threads "1 2 4 8" \
+  --nsamples 10 \
+  --repeats 1 \
+  --warmup-events 10 \
+  --radius 0.4
+```
+
+Merge both formats with the same script:
+
+```sh
+julia --project=. src/merge-thread-scan.jl \
+  results/benchmark-scan/small/julia/*/*.json \
+  results/benchmark-scan/small/fastjet/*.csv \
+  results/benchmark-scan/small/summary.csv
+```
+
+When plotting a mixed Julia/FastJet summary, include the backend and schedule in
+the line grouping. The default `--group-by algorithm,strategy,R,p` is suitable
+for Julia-only plots, but it will mix backends if a summary contains both Julia
+and FastJet rows.
+
+```sh
+julia --project=. src/plot-thread-scan.jl \
+  results/benchmark-scan/small/summary.csv \
+  results/benchmark-scan/small/plots \
+  --metric efficiency \
+  --group-by code,backend,algorithm,strategy,R,p,schedule \
+  --title "Small pp input"
+
+julia --project=. src/plot-thread-scan.jl \
+  results/benchmark-scan/small/summary.csv \
+  results/benchmark-scan/small/plots \
+  --metric throughput \
+  --group-by code,backend,algorithm,strategy,R,p,schedule \
+  --title "Small pp input" \
+  --no-ideal
+```
+
+FastJet supports `static`, `dynamic`, and `guided` OpenMP schedules. For small
+inputs, `dynamic` can be more stable because event costs are not perfectly
+uniform. Record the schedule in the CSV and keep it in the plot grouping when
+comparing schedules.
+
+To sanity-check FastJet without the Julia wrapper, run the executable directly
+on the uncompressed input:
+
+```sh
+fastjet/build/fastjet-finder \
+  -A AntiKt \
+  -p -1 \
+  -s N2Plain \
+  -R 0.4 \
+  --ptmin 5.0 \
+  -m 10 \
+  -t 4 \
+  --schedule dynamic \
+  data/events-pp-0.5TeV-5GeV.hepmc3
+```
+
+When interpreting mixed-backend scaling, compare throughput or time per event
+as well as efficiency. A backend with a faster one-thread baseline can show a
+lower parallel efficiency while still being faster in absolute time. Very short
+small-input runs are also noisy; increase `nsamples`, increase `repeats`, or
+use a higher-multiplicity input for more stable comparisons.
+
 ## Example Workload Matrix
 
 The commands below run a small pp strategy comparison:
@@ -282,17 +434,22 @@ julia --project=. src/merge-thread-scan.jl \
   results/thread-scaling/small/summary.csv
 ```
 
-The output contains one row for each workload and thread count.
+`merge-thread-scan.jl` can also merge CSV files from `benchmark.jl`, or a mix of
+JSON and CSV files, as shown in the FastJet section above. The output contains
+one row for each workload, backend, schedule, and thread count.
 
 Important columns:
 
 ```text
+code
+backend
 algorithm
 strategy
 R
 p
 input_file
 threads
+schedule
 events_per_second_median
 baseline_events_per_second_median
 speedup_median
@@ -539,5 +696,20 @@ new output directory for a new benchmark campaign.
 ### Comparing unlike workloads
 
 Speedup is only meaningful within the same workload: same algorithm, strategy,
-radius, power, and input file. `merge-thread-scan.jl` computes baselines using
-these columns, so keep them consistent across thread counts.
+radius, power, input file, code, backend, and schedule. `merge-thread-scan.jl`
+computes baselines using these columns, so keep them consistent across thread
+counts.
+
+### Mixed-backend plot grouping
+
+For Julia-only plots, the default grouping is usually enough:
+
+```text
+--group-by algorithm,strategy,R,p
+```
+
+For Julia-vs-FastJet plots, include the backend and schedule:
+
+```text
+--group-by code,backend,algorithm,strategy,R,p,schedule
+```

--- a/fastjet/CMakeLists.txt
+++ b/fastjet/CMakeLists.txt
@@ -9,6 +9,7 @@ project(FastJetBenchmarks)
 find_package(HepMC3 REQUIRED)
 find_package(fastjet REQUIRED)
 find_package(siscone REQUIRED)
+find_package(OpenMP COMPONENTS CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 
@@ -19,6 +20,9 @@ add_executable(fastjet-finder
     src/fastjet-utils.cc
 )
 
-target_link_libraries(fastjet-finder 
-    HepMC3::HepMC3 fastjet::fastjet
+target_link_libraries(fastjet-finder PRIVATE
+    fastjet::fastjet HepMC3::HepMC3
 )
+if(OpenMP_CXX_FOUND)
+    target_link_libraries(fastjet-finder PRIVATE OpenMP::OpenMP_CXX)
+endif()

--- a/fastjet/CMakeLists.txt
+++ b/fastjet/CMakeLists.txt
@@ -9,9 +9,13 @@ project(FastJetBenchmarks)
 find_package(HepMC3 REQUIRED)
 find_package(fastjet REQUIRED)
 find_package(siscone REQUIRED)
-find_package(OpenMP COMPONENTS CXX)
 
 set(CMAKE_CXX_STANDARD 17)
+option(FASTJET_ENABLE_OPENMP "Build fastjet-finder with OpenMP support" OFF)
+
+if(FASTJET_ENABLE_OPENMP)
+    include(${CMAKE_CURRENT_LIST_DIR}/cmake/FastJetOpenMP.cmake)
+endif()
 
 # Fastjet executable runs reconstruction then outputs either
 # exclusive or inclusive jets
@@ -23,6 +27,6 @@ add_executable(fastjet-finder
 target_link_libraries(fastjet-finder PRIVATE
     fastjet::fastjet HepMC3::HepMC3
 )
-if(OpenMP_CXX_FOUND)
+if(FASTJET_ENABLE_OPENMP)
     target_link_libraries(fastjet-finder PRIVATE OpenMP::OpenMP_CXX)
 endif()

--- a/fastjet/README.md
+++ b/fastjet/README.md
@@ -13,29 +13,32 @@ set `siscone_DIR`.
 
 ## Compilation
 
-Configure and compile using CMake in the standard way, e.g.,
+Configure and compile the serial executable using CMake in the standard way,
+e.g.,
 
 ```sh
 cmake -S . -B build
 cmake --build build
 ```
 
-If OpenMP is found, `fastjet-finder` is built with multi-threading support. A
-multi-threaded run will fail early if the executable was built without OpenMP.
-
-On macOS with Apple clang and Homebrew `libomp`, CMake may need the OpenMP
-settings explicitly:
+Build with OpenMP support explicitly when running multi-threaded benchmarks:
 
 ```sh
-cmake -S . -B build \
-  -DCMAKE_PREFIX_PATH=/path/to/fastjet-install \
-  -DHepMC3_DIR=/opt/homebrew/share/HepMC3/cmake \
-  -DOpenMP_CXX_FLAGS="-Xpreprocessor -fopenmp" \
-  -DOpenMP_CXX_INCLUDE_DIR=/opt/homebrew/opt/libomp/include \
-  -DOpenMP_CXX_LIB_NAMES=omp \
-  -DOpenMP_omp_LIBRARY=/opt/homebrew/opt/libomp/lib/libomp.dylib
+cmake -S . -B build -DFASTJET_ENABLE_OPENMP=ON
 cmake --build build
 ```
+
+When `FASTJET_ENABLE_OPENMP` is enabled, CMake requires OpenMP and the build
+fails if it cannot be found. On macOS with Apple clang, install Homebrew
+`libomp`; the CMake setup will try to use it automatically.
+
+```sh
+brew install libomp
+```
+
+Use the serial build for serial baseline timings. An OpenMP build run with
+`--threads 1` measures the single-thread OpenMP path, including any OpenMP
+runtime overhead.
 
 ## Applications
 
@@ -84,9 +87,10 @@ Example timing run:
 ```
 
 `src/benchmark.jl` is the usual wrapper for writing CSV benchmark results. It
-passes `--threads` and `--schedule` to `fastjet-finder` when `--code Fastjet` is
-selected, and it decompresses `.gz` input files before calling this executable.
-See `../THREAD.md` for the complete Julia-vs-FastJet thread-scaling workflow.
+passes `--worker-threads` as `--threads`, and passes `--schedule`, to
+`fastjet-finder` when `--code Fastjet` is selected. It also decompresses `.gz`
+input files before calling this executable. See `../THREAD.md` for the complete
+Julia-vs-FastJet thread-scaling workflow.
 
 ### `fastjet2json.jl`
 

--- a/fastjet/README.md
+++ b/fastjet/README.md
@@ -20,6 +20,23 @@ cmake -S . -B build
 cmake --build build
 ```
 
+If OpenMP is found, `fastjet-finder` is built with multi-threading support. A
+multi-threaded run will fail early if the executable was built without OpenMP.
+
+On macOS with Apple clang and Homebrew `libomp`, CMake may need the OpenMP
+settings explicitly:
+
+```sh
+cmake -S . -B build \
+  -DCMAKE_PREFIX_PATH=/path/to/fastjet-install \
+  -DHepMC3_DIR=/opt/homebrew/share/HepMC3/cmake \
+  -DOpenMP_CXX_FLAGS="-Xpreprocessor -fopenmp" \
+  -DOpenMP_CXX_INCLUDE_DIR=/opt/homebrew/opt/libomp/include \
+  -DOpenMP_CXX_LIB_NAMES=omp \
+  -DOpenMP_omp_LIBRARY=/opt/homebrew/opt/libomp/lib/libomp.dylib
+cmake --build build
+```
+
 ## Applications
 
 ### `fastjet-finder`
@@ -34,6 +51,7 @@ jets. This is the standard executable used to benchmark fastjet.
 Allowed options:
   -h, --help                  produce help message
   -n, --maxevents arg (=-1)   Maximum events in file to process (-1 = all events)
+  --skipevents arg (=0)       Number of events to skip over
   -m, --nsamples arg (=1)     Number of repeated trials
   -s, --strategy arg (=Best)  Valid values are 'Best' (default), 'N2Plain', 'N2Tiled'
   -A, --algorithm arg         Valid values are 'AntiKt' 'CA' 'Kt' 'GenKt' 'EEKt' 'Durham'
@@ -44,9 +62,31 @@ Allowed options:
   --njets arg                 njets value for exclusive jets
   -d, --dump arg              Filename to dump jets to
   -c, --debug-clusterseq      Dump cluster sequence history content
+  -t, --threads arg (=1)      Number of OpenMP threads to use
+  --schedule arg (=static)    OpenMP schedule: static, dynamic, or guided
 
 Note that only one of ptmin, dijmax or njets can be specified!
 ```
+
+Example timing run:
+
+```sh
+./build/fastjet-finder \
+  -A AntiKt \
+  -p -1 \
+  -s N2Plain \
+  -R 0.4 \
+  --ptmin 5.0 \
+  -m 10 \
+  -t 4 \
+  --schedule dynamic \
+  ../data/events-pp-0.5TeV-5GeV.hepmc3
+```
+
+`src/benchmark.jl` is the usual wrapper for writing CSV benchmark results. It
+passes `--threads` and `--schedule` to `fastjet-finder` when `--code Fastjet` is
+selected, and it decompresses `.gz` input files before calling this executable.
+See `../THREAD.md` for the complete Julia-vs-FastJet thread-scaling workflow.
 
 ### `fastjet2json.jl`
 

--- a/fastjet/cmake/FastJetOpenMP.cmake
+++ b/fastjet/cmake/FastJetOpenMP.cmake
@@ -1,0 +1,35 @@
+# OpenMP setup for fastjet-finder parallel builds.
+#
+# Apple clang does not ship OpenMP support, but Homebrew libomp provides it.
+# Seed CMake's FindOpenMP variables from Homebrew when available, while still
+# allowing users to override them explicitly on the cmake command line.
+
+if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES "AppleClang|Clang")
+    find_program(BREW_EXECUTABLE brew)
+    if(BREW_EXECUTABLE)
+        execute_process(
+            COMMAND "${BREW_EXECUTABLE}" --prefix libomp
+            OUTPUT_VARIABLE FASTJET_LIBOMP_PREFIX
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET
+            RESULT_VARIABLE FASTJET_LIBOMP_RESULT
+        )
+
+        if(FASTJET_LIBOMP_RESULT EQUAL 0 AND FASTJET_LIBOMP_PREFIX)
+            if(NOT OpenMP_CXX_FLAGS)
+                set(OpenMP_CXX_FLAGS "-Xpreprocessor -fopenmp" CACHE STRING "OpenMP CXX flags")
+            endif()
+            if(NOT OpenMP_CXX_INCLUDE_DIR)
+                set(OpenMP_CXX_INCLUDE_DIR "${FASTJET_LIBOMP_PREFIX}/include" CACHE PATH "OpenMP CXX include directory")
+            endif()
+            if(NOT OpenMP_CXX_LIB_NAMES)
+                set(OpenMP_CXX_LIB_NAMES "omp" CACHE STRING "OpenMP CXX library names")
+            endif()
+            if(NOT OpenMP_omp_LIBRARY)
+                set(OpenMP_omp_LIBRARY "${FASTJET_LIBOMP_PREFIX}/lib/libomp.dylib" CACHE FILEPATH "OpenMP omp library")
+            endif()
+        endif()
+    endif()
+endif()
+
+find_package(OpenMP REQUIRED COMPONENTS CXX)

--- a/fastjet/src/fastjet-finder.cc
+++ b/fastjet/src/fastjet-finder.cc
@@ -12,6 +12,11 @@
 #include <string>
 #include <vector>
 #include <chrono>
+#include <cmath>
+
+#ifdef _OPENMP
+#include <omp.h>
+#endif
 
 #include <unistd.h>
 #include <stdlib.h>
@@ -33,8 +38,10 @@ using namespace popl;
 using Time = std::chrono::high_resolution_clock;
 using us = std::chrono::microseconds;
 
-fastjet::ClusterSequence run_fastjet_clustering(std::vector<fastjet::PseudoJet> input_particles,
-  fastjet::Strategy strategy, fastjet::JetAlgorithm algorithm, fastjet::RecombinationScheme recombine_scheme, 
+static volatile size_t final_jets_sink = 0;
+
+fastjet::ClusterSequence run_fastjet_clustering(const std::vector<fastjet::PseudoJet> &input_particles,
+  fastjet::Strategy strategy, fastjet::JetAlgorithm algorithm, fastjet::RecombinationScheme recombine_scheme,
   double R, double p) {
 
   fastjet::JetDefinition jet_definition;
@@ -52,25 +59,64 @@ fastjet::ClusterSequence run_fastjet_clustering(std::vector<fastjet::PseudoJet> 
   return clust_seq;
 }
 
-void dump_clusterseq(fastjet::ClusterSequence clust_seq) {
+void dump_clusterseq(const fastjet::ClusterSequence &clust_seq, FILE *dump_fh) {
   // Print out the contents of the cluster sequence, for debug purposes
   // N.B. Indexes counted from 1 (to match Julia)
   // Jets
   auto jets = clust_seq.jets();
   auto ijets = 1;
   for (auto jet: jets) {
-    std::cout << ijets << ": px=" << jet.px() << " py=" << jet.py() << " pz=" << jet.pz() << " E=" << jet.E() << std::endl;
+    fprintf(dump_fh, "%d: px=%15.10f py=%15.10f pz=%15.10f E=%15.10f\n",
+      ijets, jet.px(), jet.py(), jet.pz(), jet.E());
     ijets++;
   } 
   // History
   auto history = clust_seq.history();
   auto ihistory = 1;
   for (auto he: history) {
-    std::cout << ihistory << ": " <<
-      he.parent1+1 << " " << he.parent2+1 << " " << he.child+1 << " " << 
-      he.dij << " " << he.max_dij_so_far << std::endl;
+    fprintf(dump_fh, "%d: %d %d %d %15.10f %15.10f\n",
+      ihistory, he.parent1+1, he.parent2+1, he.child+1, he.dij, he.max_dij_so_far);
     ihistory++;
   }
+}
+
+std::vector<fastjet::PseudoJet> select_final_jets(fastjet::ClusterSequence &cluster_sequence,
+  bool use_ptmin, double ptmin, bool use_dijmax, double dijmax, bool use_njets, int njets) {
+  if (use_ptmin) {
+    return cluster_sequence.inclusive_jets(ptmin);
+  } else if (use_dijmax) {
+    return cluster_sequence.exclusive_jets(dijmax);
+  } else if (use_njets) {
+    return cluster_sequence.exclusive_jets(njets);
+  }
+  return {};
+}
+
+void dump_event_jets(FILE *dump_fh, size_t event_number,
+  std::vector<fastjet::PseudoJet> final_jets,
+  const fastjet::ClusterSequence &cluster_sequence,
+  bool debug_clusterseq) {
+  // Sort by pt so files can be compared.
+  final_jets = fastjet::sorted_by_pt(final_jets);
+  fprintf(dump_fh, "Jets in processed event %zu\n", event_number);
+
+  for (unsigned int i = 0; i < final_jets.size(); i++) {
+    fprintf(dump_fh, "%5u %15.10f %15.10f %15.10f\n",
+      i, final_jets[i].rap(), final_jets[i].phi(),
+      final_jets[i].perp());
+  }
+
+  if (debug_clusterseq) {
+    dump_clusterseq(cluster_sequence, dump_fh);
+  }
+}
+
+size_t one_process_event(const std::vector<fastjet::PseudoJet> &input_particles,
+  fastjet::Strategy strategy, fastjet::JetAlgorithm algorithm, fastjet::RecombinationScheme recombine_scheme,
+  double R, double p, bool use_ptmin, double ptmin, bool use_dijmax, double dijmax, bool use_njets, int njets) {
+  auto cluster_sequence = run_fastjet_clustering(input_particles, strategy, algorithm, recombine_scheme, R, p);
+  auto final_jets = select_final_jets(cluster_sequence, use_ptmin, ptmin, use_dijmax, dijmax, use_njets, njets);
+  return final_jets.size();
 }
 
 int main(int argc, char* argv[]) {
@@ -83,6 +129,8 @@ int main(int argc, char* argv[]) {
   string alg = "";
   string recombine = "";
   double R = 0.4;
+  int threads = 1;
+  string schedule = "static";
   string dump_file = "";
 
   OptionParser opts("Allowed options");
@@ -100,6 +148,8 @@ int main(int argc, char* argv[]) {
   auto njets_option = opts.add<Value<int>>("", "njets", "njets value for exclusive jets");
   auto dump_option = opts.add<Value<string>>("d", "dump", "Filename to dump jets to");
   auto debug_clusterseq_option = opts.add<Switch>("c", "debug-clusterseq", "Dump cluster sequence jet and history content");
+  auto threads_option = opts.add<Value<int>>("t", "threads", "Number of threads to use (default 1)", threads, &threads);
+  auto schedule_option = opts.add<Value<string>>("", "schedule", "OpenMP schedule type (static, dynamic, guided)", schedule, &schedule);
 
   opts.parse(argc, argv);
 
@@ -117,8 +167,10 @@ int main(int argc, char* argv[]) {
     input_file = extra_args[0];
   } else if (extra_args.size() == 0) {
     std::cerr << "No <HepMC3_input_file> argument after options" << std::endl;
+    exit(EXIT_FAILURE);
   } else {
     std::cerr << "Only one <HepMC3_input_file> supported" << std::endl;
+    exit(EXIT_FAILURE);
   }
 
   // Check we only have 1 option for final jet selection
@@ -128,17 +180,51 @@ int main(int argc, char* argv[]) {
       sum << ")" << endl;
     exit(EXIT_FAILURE);
   }
+  if (trials < 1) {
+    std::cerr << "Number of repeated trials must be at least 1" << std::endl;
+    exit(EXIT_FAILURE);
+  }
+  if (skip_events < 0) {
+    std::cerr << "Number of skipped events must be non-negative" << std::endl;
+    exit(EXIT_FAILURE);
+  }
+  if (threads < 1) {
+    std::cerr << "Number of threads must be at least 1" << std::endl;
+    exit(EXIT_FAILURE);
+  }
+  if (schedule != "static" && schedule != "dynamic" && schedule != "guided") {
+    std::cerr << "Unknown OpenMP schedule type: " << schedule << std::endl;
+    exit(EXIT_FAILURE);
+  }
+  #ifndef _OPENMP
+  if (threads > 1) {
+    std::cerr << "OpenMP not supported but threads > 1 specified" << std::endl;
+    exit(EXIT_FAILURE);
+  }
+  #endif
+
+  // Keep one-time FastJet banner printing outside benchmark output and timing.
+  fastjet::ClusterSequence::set_fastjet_banner_stream(nullptr);
 
   // read in input events
   //----------------------------------------------------------
   auto events = read_input_events(input_file.c_str(), maxevents);
-  
+
+  if (events.size() == 0 || events.size() <= skip_events_option->value()) {
+    std::cerr << "No events read from input file or skipped events exceed total events in " << input_file << std::endl;
+    exit(EXIT_FAILURE);
+  }
+  const auto events_to_process = events.size() - skip_events_option->value();
+
   // Set strategy
   fastjet::Strategy strategy = fastjet::Best;
   if (mystrategy == string("N2Plain")) {
     strategy = fastjet::N2Plain;
   } else if (mystrategy == string("N2Tiled")) {
     strategy = fastjet::N2Tiled;
+  } else if (mystrategy != string("Best")) {
+    std::cout << "Unknown strategy type: " << mystrategy << std::endl;
+    exit(EXIT_FAILURE);
   }
 
   auto algorithm = fastjet::antikt_algorithm;
@@ -166,59 +252,71 @@ int main(int argc, char* argv[]) {
   }
 
   auto recombine_scheme = fastjet::RecombinationScheme::E_scheme;
-  std::cout << recombine << std::endl;
-  if (recombine == "pt_scheme") {
+  if (recombine == "" || recombine == "E_scheme") {
+    recombine_scheme = fastjet::RecombinationScheme::E_scheme;
+  } else if (recombine == "pt_scheme") {
     recombine_scheme = fastjet::RecombinationScheme::pt_scheme;
   } else if (recombine == "pt2_scheme") {
     recombine_scheme = fastjet::RecombinationScheme::pt2_scheme;
+  } else {
+    std::cout << "Unknown recombination scheme: " << recombine << std::endl;
+    exit(EXIT_FAILURE);
   }
 
   std::cout << "Strategy: " << mystrategy << "; Power: " << power << "; Algorithm " << algorithm << 
-    "; Recombine " << recombine_scheme << std::endl;
+    "; Recombine " << recombine_scheme << std::endl << "R: " << R << "; Threads: " << threads << "; Schedule: " << schedule << std::endl;
 
   auto dump_fh = stdout;
   if (dump_option->is_set()) {
     if (dump_option->value() != "-") {
       dump_fh = fopen(dump_option->value().c_str(), "w");
+      if (dump_fh == nullptr) {
+        std::cerr << "Could not open dump file " << dump_option->value() << std::endl;
+        exit(EXIT_FAILURE);
+      }
     }
   }
+
+  const bool use_ptmin = ptmin_option->is_set();
+  const bool use_dijmax = dijmax_option->is_set();
+  const bool use_njets = njets_option->is_set();
+  const double ptmin = use_ptmin ? ptmin_option->value() : 0.0;
+  const double dijmax = use_dijmax ? dijmax_option->value() : 0.0;
+  const int njets = use_njets ? njets_option->value() : 0;
+
+  #ifdef _OPENMP
+  omp_set_num_threads(threads);
+  if (schedule == "static") {
+    omp_set_schedule(omp_sched_static, 0);
+  } else if (schedule == "dynamic") {
+    omp_set_schedule(omp_sched_dynamic, 0);
+  } else if (schedule == "guided") {
+    omp_set_schedule(omp_sched_guided, 0);
+  }
+  #endif
 
   double time_total = 0.0;
   double time_total2 = 0.0;
   double sigma = 0.0;
   double time_lowest = 1.0e20;
+  size_t total_final_jets = 0;
   for (long trial = 0; trial < trials; ++trial) {
     std::cout << "Trial " << trial << " ";
     auto start_t = std::chrono::steady_clock::now();
-    for (size_t ievt = skip_events_option->value(); ievt < events.size(); ++ievt) {
-      auto cluster_sequence = run_fastjet_clustering(events[ievt], strategy, algorithm, recombine_scheme, R, power);
+    const size_t first_event = skip_events_option->value();
+    const size_t last_event = events.size();
 
-      vector<fastjet::PseudoJet> final_jets;
-      if (ptmin_option->is_set()) {
-        final_jets = cluster_sequence.inclusive_jets(ptmin_option->value());
-      } else if (dijmax_option->is_set()) {
-        final_jets = cluster_sequence.exclusive_jets(dijmax_option->value());
-      } else if (njets_option->is_set()) {
-        final_jets = cluster_sequence.exclusive_jets(njets_option->value());
+    if (threads == 1) {
+      for (size_t ievt = first_event; ievt < last_event; ++ievt) {
+        total_final_jets += one_process_event(events[ievt], strategy, algorithm, recombine_scheme, R, power, use_ptmin, ptmin, use_dijmax, dijmax, use_njets, njets);
       }
-
-      if (dump_option->is_set() && trial==0) {
-        // sort by pt so files can be compared
-        final_jets = fastjet::sorted_by_pt(final_jets);
-        fprintf(dump_fh, "Jets in processed event %zu\n", ievt+1);
-    
-        // print out the details for each jet
-        for (unsigned int i = 0; i < final_jets.size(); i++) {
-          fprintf(dump_fh, "%5u %15.10f %15.10f %15.10f\n",
-          i, final_jets[i].rap(), final_jets[i].phi(),
-          final_jets[i].perp());
-        }
-
-        // Dump the cluster sequence history content as well?
-        if (debug_clusterseq_option->is_set()) {
-          dump_clusterseq(cluster_sequence);
-        }
+    } else {
+      #ifdef _OPENMP
+      #pragma omp parallel for reduction(+:total_final_jets) schedule(runtime)
+      for (long long ievt = first_event; ievt < last_event; ++ievt) {
+        total_final_jets += one_process_event(events[ievt], strategy, algorithm, recombine_scheme, R, power, use_ptmin, ptmin, use_dijmax, dijmax, use_njets, njets);
       }
+      #endif
     }
     auto stop_t = std::chrono::steady_clock::now();
     auto elapsed = stop_t - start_t;
@@ -227,19 +325,31 @@ int main(int argc, char* argv[]) {
     time_total += us_elapsed;
     time_total2 += us_elapsed*us_elapsed;
     if (us_elapsed < time_lowest) time_lowest = us_elapsed;
+
+    if (dump_option->is_set() && trial == 0) {
+      for (size_t ievt = skip_events_option->value(); ievt < events.size(); ++ievt) {
+        auto cluster_sequence = run_fastjet_clustering(events[ievt], strategy, algorithm, recombine_scheme, R, power);
+        auto final_jets = select_final_jets(cluster_sequence, use_ptmin, ptmin, use_dijmax, dijmax, use_njets, njets);
+        dump_event_jets(dump_fh, ievt+1, final_jets, cluster_sequence, debug_clusterseq_option->is_set());
+      }
+    }
   }
-  time_total /= trials;
-  time_total2 /= trials;
+  double mean_time_total = time_total / trials;
+  double mean_time_total2 = time_total2 / trials;
   if (trials > 1) {
-    sigma = std::sqrt(double(trials)/(trials-1) * (time_total2 - time_total*time_total));
+    sigma = std::sqrt(double(trials)/(trials-1) * (mean_time_total2 - mean_time_total*mean_time_total));
   } else {
     sigma = 0.0;
   }
-  double mean_per_event = time_total / events.size();
-  double sigma_per_event = sigma / events.size();
-  time_lowest /= events.size();
-  std::cout << "Processed " << events.size() << " events, " << trials << " times" << endl;
-  std::cout << "Total time " << time_total << " us" << endl;
+  double mean_per_event = mean_time_total / events_to_process;
+  double sigma_per_event = sigma / events_to_process;
+  time_lowest /= events_to_process;
+  final_jets_sink = total_final_jets;
+  if (dump_option->is_set() && dump_option->value() != "-") {
+    fclose(dump_fh);
+  }
+  std::cout << "Processed " << events_to_process << " events, " << trials << " times" << endl;
+  std::cout << "Mean total time " << mean_time_total << " us" << endl;
   std::cout << "Time per event " << mean_per_event << " +- " << sigma_per_event << " us" << endl;
   std::cout << "Lowest time per event " << time_lowest << " us" << endl;
 

--- a/fastjet/src/fastjet-finder.cc
+++ b/fastjet/src/fastjet-finder.cc
@@ -38,8 +38,6 @@ using namespace popl;
 using Time = std::chrono::high_resolution_clock;
 using us = std::chrono::microseconds;
 
-static volatile size_t final_jets_sink = 0;
-
 fastjet::ClusterSequence run_fastjet_clustering(const std::vector<fastjet::PseudoJet> &input_particles,
   fastjet::Strategy strategy, fastjet::JetAlgorithm algorithm, fastjet::RecombinationScheme recombine_scheme,
   double R, double p) {
@@ -109,14 +107,6 @@ void dump_event_jets(FILE *dump_fh, size_t event_number,
   if (debug_clusterseq) {
     dump_clusterseq(cluster_sequence, dump_fh);
   }
-}
-
-size_t one_process_event(const std::vector<fastjet::PseudoJet> &input_particles,
-  fastjet::Strategy strategy, fastjet::JetAlgorithm algorithm, fastjet::RecombinationScheme recombine_scheme,
-  double R, double p, bool use_ptmin, double ptmin, bool use_dijmax, double dijmax, bool use_njets, int njets) {
-  auto cluster_sequence = run_fastjet_clustering(input_particles, strategy, algorithm, recombine_scheme, R, p);
-  auto final_jets = select_final_jets(cluster_sequence, use_ptmin, ptmin, use_dijmax, dijmax, use_njets, njets);
-  return final_jets.size();
 }
 
 int main(int argc, char* argv[]) {
@@ -299,24 +289,25 @@ int main(int argc, char* argv[]) {
   double time_total2 = 0.0;
   double sigma = 0.0;
   double time_lowest = 1.0e20;
-  size_t total_final_jets = 0;
   for (long trial = 0; trial < trials; ++trial) {
     std::cout << "Trial " << trial << " ";
     auto start_t = std::chrono::steady_clock::now();
     const size_t first_event = skip_events_option->value();
     const size_t last_event = events.size();
+    const bool dump_trial = dump_option->is_set() && trial == 0;
 
-    if (threads == 1) {
-      for (size_t ievt = first_event; ievt < last_event; ++ievt) {
-        total_final_jets += one_process_event(events[ievt], strategy, algorithm, recombine_scheme, R, power, use_ptmin, ptmin, use_dijmax, dijmax, use_njets, njets);
+    #ifdef _OPENMP
+    #pragma omp parallel for schedule(runtime) ordered
+    #endif
+    for (long long ievt = first_event; ievt < last_event; ++ievt) {
+      auto cluster_sequence = run_fastjet_clustering(events[ievt], strategy, algorithm, recombine_scheme, R, power);
+      auto final_jets = select_final_jets(cluster_sequence, use_ptmin, ptmin, use_dijmax, dijmax, use_njets, njets);
+      if (dump_trial) {
+        #ifdef _OPENMP
+        #pragma omp ordered
+        #endif
+        dump_event_jets(dump_fh, ievt+1, final_jets, cluster_sequence, debug_clusterseq_option->is_set());
       }
-    } else {
-      #ifdef _OPENMP
-      #pragma omp parallel for reduction(+:total_final_jets) schedule(runtime)
-      for (long long ievt = first_event; ievt < last_event; ++ievt) {
-        total_final_jets += one_process_event(events[ievt], strategy, algorithm, recombine_scheme, R, power, use_ptmin, ptmin, use_dijmax, dijmax, use_njets, njets);
-      }
-      #endif
     }
     auto stop_t = std::chrono::steady_clock::now();
     auto elapsed = stop_t - start_t;
@@ -325,15 +316,11 @@ int main(int argc, char* argv[]) {
     time_total += us_elapsed;
     time_total2 += us_elapsed*us_elapsed;
     if (us_elapsed < time_lowest) time_lowest = us_elapsed;
-
-    if (dump_option->is_set() && trial == 0) {
-      for (size_t ievt = skip_events_option->value(); ievt < events.size(); ++ievt) {
-        auto cluster_sequence = run_fastjet_clustering(events[ievt], strategy, algorithm, recombine_scheme, R, power);
-        auto final_jets = select_final_jets(cluster_sequence, use_ptmin, ptmin, use_dijmax, dijmax, use_njets, njets);
-        dump_event_jets(dump_fh, ievt+1, final_jets, cluster_sequence, debug_clusterseq_option->is_set());
-      }
-    }
   }
+  if (dump_option->is_set() && dump_option->value() != "-") {
+    fclose(dump_fh);
+  }
+
   double mean_time_total = time_total / trials;
   double mean_time_total2 = time_total2 / trials;
   if (trials > 1) {
@@ -344,10 +331,7 @@ int main(int argc, char* argv[]) {
   double mean_per_event = mean_time_total / events_to_process;
   double sigma_per_event = sigma / events_to_process;
   time_lowest /= events_to_process;
-  final_jets_sink = total_final_jets;
-  if (dump_option->is_set() && dump_option->value() != "-") {
-    fclose(dump_fh);
-  }
+
   std::cout << "Processed " << events_to_process << " events, " << trials << " times" << endl;
   std::cout << "Mean total time " << mean_time_total << " us" << endl;
   std::cout << "Time per event " << mean_per_event << " +- " << sigma_per_event << " us" << endl;

--- a/fastjet/src/fastjet-utils.cc
+++ b/fastjet/src/fastjet-utils.cc
@@ -9,13 +9,7 @@
 
 #include "fastjet/PseudoJet.hh"
 #include <iostream> // needed for io
-#include <cstdio>   // needed for io
-#include <string>
 #include <vector>
-#include <chrono>
-
-#include <unistd.h>
-#include <stdlib.h>
 
 #include "HepMC3/GenEvent.h"
 #include "HepMC3/GenParticle.h"
@@ -32,11 +26,12 @@ vector<vector<fastjet::PseudoJet>> read_input_events(const char* fname, long max
   int events_parsed = 0;
 
   std::vector<std::vector<fastjet::PseudoJet>> events;
+  if (maxevents > 0){
+    events.reserve(maxevents);
+  }
 
   while(!input_file.failed()) {
     if (maxevents >= 0 && events_parsed >= maxevents) break;
-
-    std::vector<fastjet::PseudoJet> input_particles;
 
     HepMC3::GenEvent evt(HepMC3::Units::GEV, HepMC3::Units::MM);
 
@@ -47,9 +42,10 @@ vector<vector<fastjet::PseudoJet>> read_input_events(const char* fname, long max
     if (input_file.failed()) break;
 
     ++events_parsed;
-    input_particles.clear();
+
+    vector<fastjet::PseudoJet> input_particles;
     input_particles.reserve(evt.particles().size());
-    for(auto p: evt.particles()){
+    for(const auto &p: evt.particles()){
       if(p->status() == 1){
 	      input_particles.emplace_back(p->momentum().px(),
 				     p->momentum().py(),
@@ -57,7 +53,7 @@ vector<vector<fastjet::PseudoJet>> read_input_events(const char* fname, long max
 				     p->momentum().e());
       }
     }
-    events.push_back(input_particles);
+    events.emplace_back(std::move(input_particles));
   }
 
   cout << "Read " << events_parsed << " events from " << fname << endl;

--- a/src/benchmark.jl
+++ b/src/benchmark.jl
@@ -214,7 +214,15 @@ function external_benchmark_avg_time(input_file::AbstractString;
                                      algorithm::JetAlgorithm.Algorithm = JetAlgorithm.AntiKt,
                                      strategy::RecoStrategy.Strategy,
                                      nsamples::Integer = 1,
-                                     backend::Backends.Code = Backends.Fastjet)
+                                     backend::Backends.Code = Backends.Fastjet,
+                                     threads::Integer = 1,
+                                     schedule::Union{String, Nothing} = nothing)
+    if threads < 1
+        throw(ArgumentError("threads must be at least 1"))
+    end
+    if !isnothing(schedule) && !(schedule in ("static", "dynamic", "guided"))
+        throw(ArgumentError("schedule must be one of static, dynamic, guided"))
+    end
 
     # FastJet reader cannot handle gzipped files
     if endswith(input_file, ".gz")
@@ -244,11 +252,26 @@ function external_benchmark_avg_time(input_file::AbstractString;
     push!(bench_args, "-R", string(radius))
     push!(bench_args, "--ptmin", string(ptmin))
     push!(bench_args, "-m", string(nsamples))
+    if backend == Backends.Fastjet
+        if threads > 1
+            push!(bench_args, "-t", string(threads))
+        end
+        if !isnothing(schedule)
+            push!(bench_args, "--schedule", schedule)
+        end
+    elseif threads != 1 || !isnothing(schedule)
+        @warn "Ignoring thread/schedule options for unsupported external backend" backend threads schedule
+    end
     @info "Benchmark command: $bench_bin $bench_args $input_file"
     bench_output = read(`$bench_bin $bench_args $input_file`, String)
-    min = tryparse(Float64, match(r"Lowest time per event ([\d\.]+) us", bench_output)[1])
+    m = match(r"Lowest time per event ([\d.eE+-]+) us", bench_output)
+    if isnothing(m)
+        @error "Failed to parse output from external benchmark script" bench_output
+        return 0.0
+    end
+    min = tryparse(Float64, m[1])
     if isnothing(min)
-        @error "Failed to parse output from external benchmark script"
+        @error "Failed to parse lowest time from external benchmark script" bench_output
         return 0.0
     end
     min
@@ -371,6 +394,15 @@ function parse_command_line(args)
     help = """Specific version string for the backend used - will be set automatically for Python and Julia, but Fastjet may benefit from being set manually"""
     arg_type = String
 
+    "--threads", "-t"
+    help = "Number of threads to use (if supported by the backend)"
+    arg_type = Int
+    default = 1
+
+    "--schedule"
+    help = "Schedule for the algorithm (if supported)"
+    arg_type = String
+
     "--info"
     help = "Print info level log messages"
     action = :store_true
@@ -463,7 +495,9 @@ function main()
             p = args[:power],
             strategy = args[:strategy],
             nsamples = samples,
-            backend = args[:code])
+            backend = args[:code],
+            threads = args[:threads],
+            schedule = args[:schedule])
         elseif args[:code] in (Backends.AkTPython, Backends.AkTNumPy)
             time_per_event = python_jet_process_avg_time(args[:code], event_file; ptmin = args[:ptmin],
             radius = args[:radius],
@@ -493,6 +527,10 @@ function main()
     hepmc3_files_df[:, :strategy] .= args[:strategy]
     hepmc3_files_df[:, :radius] .= args[:radius]
     hepmc3_files_df[:, :power] .= power
+    run_threads = args[:code] == Backends.JetReconstruction ? Threads.nthreads() : args[:threads]
+    run_schedule = args[:code] == Backends.Fastjet ? something(args[:schedule], "static") : missing
+    hepmc3_files_df[:, :threads] .= run_threads
+    hepmc3_files_df[:, :schedule] .= run_schedule
 
     backend = isnothing(args[:backend]) ? determine_backend(args[:code]) : args[:backend]
     backend_version = isnothing(args[:backend_version]) ? determine_backend_version(args[:code]) : args[:backend_version]
@@ -504,9 +542,12 @@ function main()
     # Write out the results
     if !isnothing(args[:results])
         if isdir(args[:results])
+            thread_suffix = run_threads == 1 ? "" : "_T$(run_threads)"
+            schedule_suffix = ismissing(run_schedule) || run_threads == 1 ? "" : "_$(run_schedule)"
             results_file = joinpath(args[:results],
             "$(args[:code])_$(args[:code_version])_$(args[:algorithm])_" *
-            "$(args[:strategy])_R$(args[:radius])_P$(power)_$(backend)_$(backend_version).csv")
+            "$(args[:strategy])_R$(args[:radius])_P$(power)_$(backend)_$(backend_version)" *
+            "$(thread_suffix)$(schedule_suffix).csv")
         else
             results_file = args[:results]
         end

--- a/src/benchmark.jl
+++ b/src/benchmark.jl
@@ -394,8 +394,8 @@ function parse_command_line(args)
     help = """Specific version string for the backend used - will be set automatically for Python and Julia, but Fastjet may benefit from being set manually"""
     arg_type = String
 
-    "--threads", "-t"
-    help = "Number of threads to use (if supported by the backend)"
+    "--worker-threads"
+    help = "Number of worker threads to use in an external backend such as FastJet"
     arg_type = Int
     default = 1
 
@@ -496,7 +496,7 @@ function main()
             strategy = args[:strategy],
             nsamples = samples,
             backend = args[:code],
-            threads = args[:threads],
+            threads = args[:worker_threads],
             schedule = args[:schedule])
         elseif args[:code] in (Backends.AkTPython, Backends.AkTNumPy)
             time_per_event = python_jet_process_avg_time(args[:code], event_file; ptmin = args[:ptmin],
@@ -527,7 +527,7 @@ function main()
     hepmc3_files_df[:, :strategy] .= args[:strategy]
     hepmc3_files_df[:, :radius] .= args[:radius]
     hepmc3_files_df[:, :power] .= power
-    run_threads = args[:code] == Backends.JetReconstruction ? Threads.nthreads() : args[:threads]
+    run_threads = args[:code] == Backends.JetReconstruction ? Threads.nthreads() : args[:worker_threads]
     run_schedule = args[:code] == Backends.Fastjet ? something(args[:schedule], "static") : missing
     hepmc3_files_df[:, :threads] .= run_threads
     hepmc3_files_df[:, :schedule] .= run_schedule

--- a/src/merge-thread-scan.jl
+++ b/src/merge-thread-scan.jl
@@ -3,14 +3,61 @@ using DataFrames
 using CSV
 using Statistics
 
-if length(ARGS) < 2
-    error("Usage: julia merge-thread-scan.jl input1.json [input2.json ...] output.csv")
+show_help = any(arg -> arg in ("-h", "--help"), ARGS)
+if length(ARGS) < 2 || show_help
+    println("Usage: julia merge-thread-scan.jl input1.json/input1.csv [input2 ...] output.csv")
+    println()
+    println("Inputs can be JSON files from thread-run.jl or CSV files from benchmark.jl.")
+    exit(show_help ? 0 : 1)
 end
 
 input_files = ARGS[1:end-1]
 output_file = ARGS[end]
 
-rows=[]
+const ROW_COLUMNS = (
+    :source_file,
+    :source_format,
+    :code,
+    :code_version,
+    :backend,
+    :backend_version,
+    :threads,
+    :schedule,
+    :events_per_second,
+    :algorithm,
+    :strategy,
+    :R,
+    :p,
+    :input_file,
+    :input_event_count,
+    :measured_events,
+    :nsamples,
+    :repeats,
+    :warmup_events,
+    :julia_version,
+    :wall_time_seconds,
+    :time_per_event_seconds,
+    :allocated_bytes_total,
+    :allocated_bytes_per_event,
+    :gc_fraction,
+    :benchmark_command,
+    :repo_commit,
+    :repo_short_commit,
+    :repo_branch,
+    :repo_dirty,
+    :remote_origin,
+    :package_commit,
+    :jetreconstruction_version,
+    :jetreconstruction_source,
+    :cpu_threads,
+    :cpu_model,
+    :machine,
+    :kernel,
+    :total_memory_bytes,
+    :julia_project,
+    :julia_num_gc_threads,
+    :julia_exclusive,
+)
 
 get_nested(data, keys...; default = missing) = foldl(
     (value, key) -> value isa AbstractDict && haskey(value, key) ? value[key] : default,
@@ -18,113 +65,287 @@ get_nested(data, keys...; default = missing) = foldl(
     init = data,
 )
 
-maybe_string(value) = ismissing(value) || isnothing(value) ? missing : String(value)
-maybe_float(value) = ismissing(value) || isnothing(value) ? missing : Float64(value)
-maybe_int(value) = ismissing(value) || isnothing(value) ? missing : Int(value)
+is_missing_like(value) = ismissing(value) || isnothing(value)
+
+function maybe_string(value)
+    is_missing_like(value) && return missing
+    return string(value)
+end
+
+function string_or(value, default::AbstractString)
+    is_missing_like(value) && return default
+    text = string(value)
+    return isempty(text) ? default : text
+end
+
+function maybe_float(value)
+    is_missing_like(value) && return missing
+    return Float64(value)
+end
+
+function maybe_int(value)
+    is_missing_like(value) && return missing
+    return Int(value)
+end
+
+function maybe_bool(value)
+    is_missing_like(value) && return missing
+    return Bool(value)
+end
+
+function positive_or_missing(value)
+    parsed = maybe_float(value)
+    if ismissing(parsed)
+        return missing
+    end
+    if parsed <= 0
+        error("time_per_event must be positive, got $(parsed)")
+    end
+    return parsed
+end
+
+function divide_or_missing(numerator, denominator)
+    if is_missing_like(numerator) || is_missing_like(denominator)
+        return missing
+    end
+    denominator == 0 && return missing
+    return Float64(numerator) / Float64(denominator)
+end
+
+function median_skipmissing(values)
+    numeric = Float64[]
+    for value in values
+        is_missing_like(value) || push!(numeric, Float64(value))
+    end
+    return isempty(numeric) ? missing : median(numeric)
+end
+
+function first_skipmissing(values)
+    for value in values
+        is_missing_like(value) || return value
+    end
+    return missing
+end
+
+function require_columns(df::DataFrame, columns::Vector{Symbol}, filename::AbstractString)
+    missing_columns = setdiff(columns, propertynames(df))
+    if !isempty(missing_columns)
+        error("$(filename) is missing required column(s): $(join(string.(missing_columns), ", "))")
+    end
+end
+
+function row_tuple(; kwargs...)
+    values = Dict{Symbol, Any}(kwargs)
+    return NamedTuple{ROW_COLUMNS}(Tuple(get(values, col, missing) for col in ROW_COLUMNS))
+end
+
+function schedule_label(code, schedule)
+    if is_missing_like(schedule) || isempty(string(schedule))
+        return string(code) == "Fastjet" ? "static" : "julia_threads_default"
+    end
+    return string(schedule)
+end
+
+function benchmark_backend_default(code)
+    code_text = string(code)
+    if code_text == "JetReconstruction"
+        return "Julia"
+    elseif code_text == "Fastjet" || code_text == "CJetReconstruction"
+        return "C++"
+    elseif code_text == "AkTPython" || code_text == "AkTNumPy"
+        return "Python"
+    end
+    return "unknown"
+end
+
+function parse_json_file!(rows, filename::AbstractString)
+    data = JSON.parsefile(filename)
+    if !Bool(data["success"])
+        @warn "Skipping file due to unsuccessful run" filename
+        return
+    end
+
+    measured_events = maybe_int(get(data, "measured_events", missing))
+    wall_time_seconds = maybe_float(get_nested(data, "summary", "wall_time_seconds_median"))
+    time_per_event_seconds = maybe_float(get_nested(data, "summary", "time_per_event_seconds_median"))
+    if ismissing(time_per_event_seconds)
+        time_per_event_seconds = divide_or_missing(wall_time_seconds, measured_events)
+    end
+
+    allocated_bytes_total = maybe_float(get_nested(data, "summary", "allocated_bytes_total_median"))
+    allocated_bytes_per_event = divide_or_missing(allocated_bytes_total, measured_events)
+
+    julia_version = string_or(get(data, "julia_version", missing), "unknown")
+    jetreconstruction_version = maybe_string(get_nested(data, "packages", "JetReconstruction", "version"))
+
+    push!(rows, row_tuple(
+        source_file = filename,
+        source_format = "json",
+        code = string_or(get(data, "code", missing), "JetReconstruction"),
+        code_version = string_or(get(data, "code_version", missing), ismissing(jetreconstruction_version) ? "unknown" : jetreconstruction_version),
+        backend = string_or(get(data, "backend", missing), "Julia"),
+        backend_version = string_or(get(data, "backend_version", missing), julia_version),
+        threads = maybe_int(get(data, "threads", get(data, "julia_threads", missing))),
+        schedule = string_or(get(data, "schedule", missing), "julia_threads_default"),
+        events_per_second = maybe_float(get_nested(data, "summary", "events_per_second_median")),
+        algorithm = string_or(get(data, "algorithm", missing), "unknown"),
+        strategy = string_or(get(data, "strategy", missing), "unknown"),
+        R = maybe_float(get(data, "R", missing)),
+        p = maybe_float(get(data, "p", missing)),
+        input_file = string_or(get(data, "input_file", missing), "unknown"),
+        input_event_count = maybe_int(get(data, "input_event_count", missing)),
+        measured_events = measured_events,
+        nsamples = maybe_int(get(data, "nsamples", missing)),
+        repeats = maybe_int(get(data, "repeats", missing)),
+        warmup_events = maybe_int(get(data, "warmup_events", missing)),
+        julia_version = julia_version,
+        wall_time_seconds = wall_time_seconds,
+        time_per_event_seconds = time_per_event_seconds,
+        allocated_bytes_total = allocated_bytes_total,
+        allocated_bytes_per_event = allocated_bytes_per_event,
+        gc_fraction = maybe_float(get_nested(data, "summary", "gc_fraction_median")),
+        benchmark_command = maybe_string(get(data, "benchmark_command", missing)),
+        repo_commit = maybe_string(get_nested(data, "git", "commit")),
+        repo_short_commit = maybe_string(get_nested(data, "git", "short_commit")),
+        repo_branch = maybe_string(get_nested(data, "git", "branch")),
+        repo_dirty = maybe_bool(get_nested(data, "git", "is_dirty")),
+        remote_origin = maybe_string(get_nested(data, "git", "remote_origin")),
+        package_commit = maybe_string(get(data, "package_commit", missing)),
+        jetreconstruction_version = jetreconstruction_version,
+        jetreconstruction_source = maybe_string(get_nested(data, "packages", "JetReconstruction", "source")),
+        cpu_threads = maybe_int(get_nested(data, "hardware", "cpu_threads")),
+        cpu_model = maybe_string(get_nested(data, "hardware", "cpu_model")),
+        machine = maybe_string(get_nested(data, "hardware", "machine")),
+        kernel = maybe_string(get_nested(data, "hardware", "kernel")),
+        total_memory_bytes = maybe_int(get_nested(data, "hardware", "total_memory_bytes")),
+        julia_project = maybe_string(get_nested(data, "runtime", "julia_project")),
+        julia_num_gc_threads = maybe_string(get_nested(data, "runtime", "environment", "JULIA_NUM_GC_THREADS")),
+        julia_exclusive = maybe_string(get_nested(data, "runtime", "environment", "JULIA_EXCLUSIVE")),
+    ))
+end
+
+function column_value(row, column::Symbol, default = missing)
+    return hasproperty(row, column) ? getproperty(row, column) : default
+end
+
+function parse_csv_file!(rows, filename::AbstractString)
+    df = CSV.read(filename, DataFrame)
+    require_columns(df, [:time_per_event, :code, :algorithm, :strategy, :radius, :power, :threads], filename)
+
+    for row in eachrow(df)
+        time_per_event_us = positive_or_missing(row.time_per_event)
+        time_per_event_seconds = time_per_event_us * 1e-6
+        code = string_or(row.code, "unknown")
+        backend = string_or(column_value(row, :backend), benchmark_backend_default(code))
+        input_file = if hasproperty(row, :File_path)
+            string_or(row.File_path, "unknown")
+        elseif hasproperty(row, :input_file)
+            string_or(row.input_file, "unknown")
+        elseif hasproperty(row, :File)
+            string_or(row.File, "unknown")
+        else
+            error("$(filename) is missing an input file column; expected File_path, input_file, or File")
+        end
+
+        push!(rows, row_tuple(
+            source_file = filename,
+            source_format = "csv",
+            code = code,
+            code_version = string_or(column_value(row, :code_version), "unknown"),
+            backend = backend,
+            backend_version = string_or(column_value(row, :backend_version), "unknown"),
+            threads = maybe_int(row.threads),
+            schedule = schedule_label(code, column_value(row, :schedule)),
+            events_per_second = 1.0 / time_per_event_seconds,
+            algorithm = string_or(row.algorithm, "unknown"),
+            strategy = string_or(row.strategy, "unknown"),
+            R = maybe_float(row.radius),
+            p = maybe_float(row.power),
+            input_file = input_file,
+            input_event_count = missing,
+            measured_events = missing,
+            nsamples = maybe_int(column_value(row, :n_samples)),
+            repeats = missing,
+            warmup_events = missing,
+            julia_version = string_or(column_value(row, :backend_version), "unknown"),
+            wall_time_seconds = missing,
+            time_per_event_seconds = time_per_event_seconds,
+            allocated_bytes_total = missing,
+            allocated_bytes_per_event = missing,
+            gc_fraction = missing,
+        ))
+    end
+end
+
+rows = NamedTuple{ROW_COLUMNS}[]
 
 for filename in input_files
-    data = JSON.parsefile(filename)
-    if !data["success"]
-        @warn "Skipping file $filename due to unsuccessful run"
+    if filename == output_file
+        @warn "Skipping output file listed as input" filename
         continue
     end
 
-    threads = Int(data["julia_threads"])
-    events_per_second = Float64(data["summary"]["events_per_second_median"])
-    algorithm = String(data["algorithm"])
-    strategy = String(data["strategy"])
-    R = Float64(data["R"])
-    p = Float64(data["p"])
-    input_file = String(data["input_file"])
-    input_event_count = Int(data["input_event_count"])
-    measured_events = Int(data["measured_events"])
-    nsamples = Int(data["nsamples"])
-    repeats = Int(data["repeats"])
-    warmup_events = Int(data["warmup_events"])
-    julia_version = String(data["julia_version"])
-    wall_time_seconds = Float64(data["summary"]["wall_time_seconds_median"])
-    time_per_event_seconds = wall_time_seconds / measured_events
-    allocated_bytes_total = Float64(data["summary"]["allocated_bytes_total_median"])
-    allocated_bytes_per_event = allocated_bytes_total / measured_events
-    gc_fraction = Float64(data["summary"]["gc_fraction_median"])
-    benchmark_command = maybe_string(get(data, "benchmark_command", missing))
-    repo_commit = maybe_string(get_nested(data, "git", "commit"))
-    repo_short_commit = maybe_string(get_nested(data, "git", "short_commit"))
-    repo_branch = maybe_string(get_nested(data, "git", "branch"))
-    repo_dirty = get_nested(data, "git", "is_dirty")
-    remote_origin = maybe_string(get_nested(data, "git", "remote_origin"))
-    package_commit = maybe_string(get(data, "package_commit", missing))
-    jetreconstruction_version = maybe_string(get_nested(data, "packages", "JetReconstruction", "version"))
-    jetreconstruction_source = maybe_string(get_nested(data, "packages", "JetReconstruction", "source"))
-    cpu_threads = maybe_int(get_nested(data, "hardware", "cpu_threads"))
-    cpu_model = maybe_string(get_nested(data, "hardware", "cpu_model"))
-    machine = maybe_string(get_nested(data, "hardware", "machine"))
-    kernel = maybe_string(get_nested(data, "hardware", "kernel"))
-    total_memory_bytes = maybe_int(get_nested(data, "hardware", "total_memory_bytes"))
-    julia_project = maybe_string(get_nested(data, "runtime", "julia_project"))
-    julia_num_gc_threads = maybe_string(get_nested(data, "runtime", "environment", "JULIA_NUM_GC_THREADS"))
-    julia_exclusive = maybe_string(get_nested(data, "runtime", "environment", "JULIA_EXCLUSIVE"))
-
-    push!(rows, (threads=threads, events_per_second=events_per_second, algorithm=algorithm, strategy=strategy, 
-    R=R, p=p, input_file=input_file, input_event_count=input_event_count, 
-    measured_events=measured_events, nsamples=nsamples, repeats=repeats, 
-    warmup_events=warmup_events, julia_version=julia_version,
-    wall_time_seconds=wall_time_seconds, time_per_event_seconds=time_per_event_seconds,
-    allocated_bytes_total=allocated_bytes_total, allocated_bytes_per_event=allocated_bytes_per_event,
-    gc_fraction=gc_fraction, benchmark_command=benchmark_command,
-    repo_commit=repo_commit, repo_short_commit=repo_short_commit, repo_branch=repo_branch,
-    repo_dirty=repo_dirty, remote_origin=remote_origin,
-    package_commit=package_commit, jetreconstruction_version=jetreconstruction_version,
-    jetreconstruction_source=jetreconstruction_source,
-    cpu_threads=cpu_threads, cpu_model=cpu_model, machine=machine, kernel=kernel,
-    total_memory_bytes=total_memory_bytes, julia_project=julia_project,
-    julia_num_gc_threads=julia_num_gc_threads, julia_exclusive=julia_exclusive))
+    ext = lowercase(splitext(filename)[2])
+    if ext == ".json"
+        parse_json_file!(rows, filename)
+    elseif ext == ".csv"
+        parse_csv_file!(rows, filename)
+    else
+        error("Unsupported input extension for $(filename); expected .json or .csv")
+    end
 end
+
+isempty(rows) && error("No successful input rows to merge")
 
 df = DataFrame(rows)
 
-workload_cols = [:algorithm, :strategy, :R, :p, :input_file]
+workload_cols = [:code, :code_version, :backend, :backend_version, :algorithm, :strategy, :R, :p, :input_file]
+group_cols = vcat(workload_cols, [:threads, :schedule])
+
 grouped = combine(
-    groupby(df, vcat(workload_cols, [:threads])),
-    :events_per_second => median => :events_per_second_median,
-    :wall_time_seconds => median => :wall_time_seconds_median,
-    :time_per_event_seconds => median => :time_per_event_seconds_median,
-    :allocated_bytes_total => median => :allocated_bytes_total_median,
-    :allocated_bytes_per_event => median => :allocated_bytes_per_event_median,
-    :gc_fraction => median => :gc_fraction_median,
-    :input_event_count => first => :input_event_count,
-    :measured_events => first => :measured_events,
-    :nsamples => first => :nsamples,
-    :repeats => first => :repeats,
-    :warmup_events => first => :warmup_events,
-    :julia_version => first => :julia_version,
-    :benchmark_command => first => :benchmark_command,
-    :repo_commit => first => :repo_commit,
-    :repo_short_commit => first => :repo_short_commit,
-    :repo_branch => first => :repo_branch,
-    :repo_dirty => first => :repo_dirty,
-    :remote_origin => first => :remote_origin,
-    :package_commit => first => :package_commit,
-    :jetreconstruction_version => first => :jetreconstruction_version,
-    :jetreconstruction_source => first => :jetreconstruction_source,
-    :cpu_threads => first => :cpu_threads,
-    :cpu_model => first => :cpu_model,
-    :machine => first => :machine,
-    :kernel => first => :kernel,
-    :total_memory_bytes => first => :total_memory_bytes,
-    :julia_project => first => :julia_project,
-    :julia_num_gc_threads => first => :julia_num_gc_threads,
-    :julia_exclusive => first => :julia_exclusive,
+    groupby(df, group_cols),
+    :events_per_second => median_skipmissing => :events_per_second_median,
+    :wall_time_seconds => median_skipmissing => :wall_time_seconds_median,
+    :time_per_event_seconds => median_skipmissing => :time_per_event_seconds_median,
+    :allocated_bytes_total => median_skipmissing => :allocated_bytes_total_median,
+    :allocated_bytes_per_event => median_skipmissing => :allocated_bytes_per_event_median,
+    :gc_fraction => median_skipmissing => :gc_fraction_median,
+    :input_event_count => first_skipmissing => :input_event_count,
+    :measured_events => first_skipmissing => :measured_events,
+    :nsamples => first_skipmissing => :nsamples,
+    :repeats => first_skipmissing => :repeats,
+    :warmup_events => first_skipmissing => :warmup_events,
+    :julia_version => first_skipmissing => :julia_version,
+    :benchmark_command => first_skipmissing => :benchmark_command,
+    :repo_commit => first_skipmissing => :repo_commit,
+    :repo_short_commit => first_skipmissing => :repo_short_commit,
+    :repo_branch => first_skipmissing => :repo_branch,
+    :repo_dirty => first_skipmissing => :repo_dirty,
+    :remote_origin => first_skipmissing => :remote_origin,
+    :package_commit => first_skipmissing => :package_commit,
+    :jetreconstruction_version => first_skipmissing => :jetreconstruction_version,
+    :jetreconstruction_source => first_skipmissing => :jetreconstruction_source,
+    :cpu_threads => first_skipmissing => :cpu_threads,
+    :cpu_model => first_skipmissing => :cpu_model,
+    :machine => first_skipmissing => :machine,
+    :kernel => first_skipmissing => :kernel,
+    :total_memory_bytes => first_skipmissing => :total_memory_bytes,
+    :julia_project => first_skipmissing => :julia_project,
+    :julia_num_gc_threads => first_skipmissing => :julia_num_gc_threads,
+    :julia_exclusive => first_skipmissing => :julia_exclusive,
+    nrow => :raw_rows,
 )
 
-baseline = grouped[
+baseline_rows = grouped[
     grouped.threads .== 1,
     vcat(workload_cols, [:events_per_second_median])
 ]
 
-rename!(
-    baseline,
-    :events_per_second_median => :baseline_events_per_second_median
+nrow(baseline_rows) == 0 && error("Cannot compute speedup: no 1-thread baseline rows found")
+
+baseline = combine(
+    groupby(baseline_rows, workload_cols),
+    :events_per_second_median => median_skipmissing => :baseline_events_per_second_median,
 )
 
 grouped = leftjoin(grouped, baseline, on = workload_cols)
@@ -139,6 +360,11 @@ grouped.speedup_median =
 grouped.efficiency_median =
     grouped.speedup_median ./ grouped.threads
 
-sort!(grouped, vcat(workload_cols, [:threads]))
+sort!(grouped, vcat(workload_cols, [:schedule, :threads]))
+
+parent = dirname(output_file)
+if !isempty(parent) && parent != "."
+    mkpath(parent)
+end
 
 CSV.write(output_file, grouped)


### PR DESCRIPTION
## Summary

- Added FastJet thread-scaling documentation across `README.md`, `THREAD.md`, and `fastjet/README.md`.
- Documented the finalized workflow:
  - Julia: `thread-run.jl` / `thread-scan.sh` / `thread-benchmark-all.sh` JSON path.
  - FastJet: `benchmark.jl --code Fastjet` CSV path.
  - Shared merge/plot path through `merge-thread-scan.jl` and `plot-thread-scan.jl`.
- Added OpenMP build notes for FastJet, including macOS/Homebrew `libomp` CMake flags.
- Documented `--threads` and `--schedule` usage for FastJet benchmarking.
- Added guidance for mixed Julia/FastJet plots using:
  `--group-by code,backend,algorithm,strategy,R,p,schedule`
- Clarified interpretation of throughput vs speedup/efficiency, especially when one-thread baselines differ.
- Fixed `src/merge-thread-scan.jl --help` to exit cleanly with status 0.